### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Free-form, minimalistic specs (tests) that favor natural language
 
 [![Build Status](https://travis-ci.org/PolyglotSymposium/pyfreeverse.svg)](https://travis-ci.org/PolyglotSymposium/pyfreeverse)
-[![Latest Version](https://img.shields.io/pypi/v/freeverse.svg
+[![Latest Version](https://img.shields.io/pypi/v/freeverse.svg)](https://pypi.python.org/pypi/freeverse/)
 
 I'm trying to pioneer a new style of specs. So far I have just slapped a bunch
 of code together as a sort of brain dump. Soon it will be time to slow down and

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Free-form, minimalistic specs (tests) that favor natural language
 
 [![Build Status](https://travis-ci.org/PolyglotSymposium/pyfreeverse.svg)](https://travis-ci.org/PolyglotSymposium/pyfreeverse)
-[![Latest Version](https://pypip.in/version/freeverse/badge.svg)](https://pypi.python.org/pypi/freeverse/)
+[![Latest Version](https://img.shields.io/pypi/v/freeverse.svg
 
 I'm trying to pioneer a new style of specs. So far I have just slapped a bunch
 of code together as a sort of brain dump. Soon it will be time to slow down and


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20freeverse))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `freeverse`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.